### PR TITLE
Replace tao with winit to support GUI in Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ order-stat = "0.1"
 pest = "2"
 pest_consume = "1"
 pest_derive = "2"
-pixels = "0.13"
+pixels = "0.14" # v0.15 breaks the winit application because it introduces lifetimes on Pixels.
 ply-rs = "0.1"
 regex = "1"
 shared_arena = "0.8"
-tao = { version = "0.28", features = ["rwh_05"] }
+winit = { version = "0.30", features = ["rwh_05"] }
 
 [profile.dev]
 opt-level = 0

--- a/api/src/parser/common.rs
+++ b/api/src/parser/common.rs
@@ -17,11 +17,15 @@ impl Pbrt {
     ///
     /// * `api` - The PBRT API interface.
     pub(crate) fn process(&self, api: &mut Api) {
-        self.stmts.iter().for_each(|stmt| stmt.process(api));
+        self.stmts.iter().for_each(|stmt| {
+            //eprintln!("Statement {:?}", stmt);
+            stmt.process(api)
+        });
     }
 }
 
 /// Represents the `stmt` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum Stmt {
     Include(String, String), // include_stmt(abs_path, params)
     Block(BlockStmt),        // block_stmt
@@ -51,6 +55,7 @@ impl Stmt {
 }
 
 /// Represents the `block_stmt` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum BlockStmt {
     WorldBegin,          // world_begin_stmt
     WorldEnd,            // world_end_stmt
@@ -81,6 +86,7 @@ impl BlockStmt {
 }
 
 /// Represents the `option_stmt` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum OptionStmt {
     Accelerator(String, Vec<Param>),     // accelerator_stmt(name, params)
     Camera(String, Vec<Param>),          // camera_stmt(name, params)
@@ -130,6 +136,7 @@ impl OptionStmt {
 }
 
 /// Represents the `scene_stmt` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum SceneStmt {
     AreaLightSource(String, Vec<Param>),         // area_light_source_stmt(name, params)
     LightSource(String, Vec<Param>),             // light_source_stmt(name, params)
@@ -188,6 +195,7 @@ impl SceneStmt {
 }
 
 /// Represents the `ctm_stmt` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum CTMStmt {
     Identity,                                   // identity_stmt
     Translate([Float; 3]),                      // translate_stmt(x, y, z)
@@ -224,6 +232,7 @@ impl CTMStmt {
 }
 
 /// Represents the `active_transform_time` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum ActiveTransformTime {
     Start, // StartTime
     End,   // EndTime
@@ -231,12 +240,14 @@ pub(crate) enum ActiveTransformTime {
 }
 
 /// Represents the `colour_type` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum ColourType {
     RGB, // colour, color, rgb
     XYZ, // xyz
 }
 
 /// Represents the `param` rule of the PBRT file.
+#[derive(Debug)]
 pub(crate) enum Param {
     Point3d(String, Vec<Point3f>),          // point_3d_param(name, p)
     Vector3d(String, Vec<Vector3f>),        // vector_3d_param(name, v)

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -41,7 +41,10 @@ fn main() -> Result<(), String> {
         thread::spawn(|| render_all());
 
         // Display a window and run it's event loop.
-        run_event_loop()
+        match run_event_loop() {
+            Ok(()) => Ok(()),
+            Err(e) => Err(format!("Error: {}", e)),
+        }
     } else {
         // Just run the main rendering function.
         render_all();

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ pest = { workspace = true }
 pest_derive = { workspace = true }
 pixels = { workspace = true }
 regex = { workspace = true }
-tao = { workspace = true }
+winit = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/core/src/integrator/sampler_integrator.rs
+++ b/core/src/integrator/sampler_integrator.rs
@@ -1,7 +1,6 @@
 //! Sampler Integrator
 
 use super::*;
-use crate::app::request_preview_redraw;
 use crate::app::OPTIONS;
 use crate::camera::*;
 use crate::film::FilmTile;
@@ -280,9 +279,6 @@ pub trait SamplerIntegrator: Integrator + Send + Sync {
 
                         // Merge image tile into `Film`.
                         camera_data.film.merge_film_tile(&film_tile, 1.0);
-
-                        // Request a redraw of the preview window.
-                        request_preview_redraw();
 
                         progress.inc(1);
                     }


### PR DESCRIPTION
For some reason tao would not refresh the rendered preview in linux. This switches it over to use winit instead.